### PR TITLE
track privacy status and window id of basic window events with ugly work...

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -94,6 +94,11 @@ let aboutClick = exports.aboutClick = function(clickEvt,window){
 
 }
 
+//complete hack to get id of BrowserWindow
+let getBrowserWinId = exports.getBrowserWinId = function(window){
+	let tabs = window.tabs;
+	return winIdFromTab(tabs[0]);
+}
 
 /** simplified tracker
   */

--- a/lib/window-tab-events.js
+++ b/lib/window-tab-events.js
@@ -6,7 +6,7 @@ const winUtils = require("sdk/deprecated/window-utils");
 const {getTabs, getTabId, getOwnerWindow} = require("sdk/tabs/utils");
 const {getOuterId,isWindowPrivate,isBrowser,getMostRecentBrowserWindow} = require("sdk/window/utils");
 
-const {eventOf, winIdFromTab, emit, Track, browserOnly} =  require("./utils");
+const {eventOf, winIdFromTab, emit, getBrowserWinId, Track, browserOnly} =  require("./utils");
 
 let isPrivate = function() false;
 
@@ -133,13 +133,12 @@ let basicTabEvents = function() {
   */
 }();
 
-
-
 let describeWindow = function(window) {
   let OUT = {
     group: "windows",
-    windowid: window.id,
+    windowid: getBrowserWinId(window),
     ntabs:  window.tabs.length,
+    private: false
   };
   if (isPrivate(window)) OUT.private = true;
 


### PR DESCRIPTION
...around

ugly but obvious hack to get window id from a browserWindow: get the corresponding window id from the first tab in browserWindow.tabs. Gross.
